### PR TITLE
Use dynamic matching for issue types and branch prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can specify the Atlassian Jira pass in the `config.json` or via `JIRA_PASS` 
 
 ### Usage
 
-Run the command below for getting all available commands. 
+Run the command below for getting all available commands.
 ```
 $ jira help
 ```
@@ -42,12 +42,10 @@ This will create a branch by this command:
 git checkout -b feature/ISSUE-KEY_your_issue_summary_here master
 ```
 
-Currently implemented two types of prefix:
-* Story - will create a branch with the prefix **feature**
-* Bug - will create a branch with the prefix **bugfix**
+You should implement a mapping for matching an issue key with a branch prefix in the `prefix` section of the `config.json` file.
 
 Options:
-* **-p, --prefix** - custom branch prefix 
+* **-p, --prefix** - custom branch prefix
 * **-m, --master** - master branch
 
 #### open: open Atlassian Jira issue in a browser

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -56,19 +56,27 @@ func runBranchCmd(cmd *cobra.Command, args []string) {
 	}
 
 	if prefix == "" {
-		switch issue.Fields.IssueType.Name {
-		case "Story":
-			prefix = config.Git.Branches.Feature
-		case "Bug":
-			prefix = config.Git.Branches.Hotfix
-		}
+		prefix = branchPrefix(config, issue.Fields.IssueType.Name)
 	}
 
 	if master == "" {
-		master = config.Git.Branches.Master
+		master = config.Branch.Master
 	}
 
 	createBranch(*issue, config, prefix)
+}
+
+func branchPrefix(config lib.Config, issueTypeName string) string {
+	prefix := ""
+
+	for issueType, branchPrefix := range config.Branch.Prefixes {
+		if issueTypeName == issueType {
+			prefix = branchPrefix
+			break
+		}
+	}
+
+	return prefix
 }
 
 func createBranch(issue lib.Issue, config lib.Config, prefix string) {
@@ -79,7 +87,7 @@ func createBranch(issue lib.Issue, config lib.Config, prefix string) {
 
 	git := lib.Git{}
 
-	git.CreateBranch(branchName, config.Git.Branches.Master)
+	git.CreateBranch(branchName, config.Branch.Master)
 }
 
 func prepareBranchName(str string) string {

--- a/config.json.example
+++ b/config.json.example
@@ -5,11 +5,16 @@
     "browse_path": "/browse",
     "user": "your@mail.com",
     "pass": "your jira pas",
-    "git": {
-        "branches": {
-            "master": "master",
-            "feature": "feature",
-            "hotfix": "bugfix"
+    "branch": {
+        "master": "master",
+        "prefixes": {
+            "Feature": "feature",
+            "Bug": "bugfix",
+            "Story": "story",
+            "Tech Task": "tech_task",
+            "Spike": "spike",
+            "Implementation Task": "implementation_task",
+            "Problem": "problem"
         }
     }
 }

--- a/lib/commands.go
+++ b/lib/commands.go
@@ -2,21 +2,24 @@ package lib
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/fatih/color"
 )
 
 func ExecuteCommand(command string, args []string) {
-
 	cmd := exec.Command(command, args...)
-
-	c := color.New(color.FgGreen)
-	c.Println("run: ", strings.Join(cmd.Args, " "))
 
 	err := cmd.Run()
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
+
+	c := color.New(color.FgGreen)
+	c.Print("=> create branch ")
+	fmt.Print("\"" + args[2] + "\"")
+	fmt.Println()
+	c.Println("=> checkout to created branch")
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -13,20 +13,15 @@ type Config struct {
 	IssuePath       string `json:"issue_path"`
 	BrowseIssuePath string `json:"browse_path"`
 	User            string `json:"user"`
-	Git             git    `json:"git"`
+	Branch          branch `json:"branch"`
 	Password        string
 	IssueURI        string
 	BrowseIssueURI  string
 }
 
-type git struct {
-	Branches branch `json:"branches"`
-}
-
 type branch struct {
-	Master  string `json:"master"`
-	Feature string `json:"feature"`
-	Hotfix  string `json:"hotfix"`
+	Master   string            `json:"master"`
+	Prefixes map[string]string `json:"prefixes"`
 }
 
 func (config *Config) SetDefaults() {


### PR DESCRIPTION
Implement dynamic settings for mapping Atlassian Jira types and branch prefixes:

```json
{
       "branch": {
        "prefixes": {
            "Feature": "feature",
            "Bug": "bugfix",
            "Story": "story",
            "Tech Task": "tech_task",
            "Spike": "spike",
            "Implementation Task": "implementation_task",
            "Problem": "problem"
        }
    }
```